### PR TITLE
Fix bug: two restaurants of the same name can be added to favourites

### DIFF
--- a/Assets/javascript.js
+++ b/Assets/javascript.js
@@ -110,7 +110,7 @@ function createFaveBtn(restaurant) {
 
         if (btnText === "Add to Favourite") {
             for (var i = 0; i < storedFaves.length; i++) {
-                if (storedFaves[i].name === faveList.name) {
+                if (storedFaves[i].location === faveList.location) {
                     storedFaves.splice(i, 1);
                 }
             }


### PR DESCRIPTION
- Previously, two restaurants with the same name couldn't be in storage at the same time
- Changed method of determining whether restaurant is already stored to checking location instead of restaurant name